### PR TITLE
Add task-list button for common_mark

### DIFF
--- a/src/styles/components/_jstoolbar.scss
+++ b/src/styles/components/_jstoolbar.scss
@@ -82,6 +82,14 @@ div.jstElements {
       font-size: 16px;
     }
   }
+  .jstb_tl {
+    padding: 0px;
+    &:before {
+      /* fa-list-check */
+      @include fontAwesome('f0ae', 'Solid');
+      font-size: 16px;
+    }
+  }
   .jstb_bq {
     padding: 0px;
     &:before {


### PR DESCRIPTION
The common mark formater (and probably the redcarpet markdown formater too) introduces a task list button. This PR adds a corresponding FA image to the toolbar.