### PR TITLE
Add macro button to toolbar

### DIFF
--- a/src/styles/components/_jstoolbar.scss
+++ b/src/styles/components/_jstoolbar.scss
@@ -133,4 +133,12 @@ div.jstElements {
     @include fontAwesome('f059', 'Solid');
     font-size: 12px;
   }
+  .jstb_macros {
+    padding: 0px;
+    &:before {
+      /* fa-puzzle-piece */
+      @include fontAwesome('f12e', 'Solid');
+      font-size: 14px;
+    }
+  }
 }


### PR DESCRIPTION
The [Additionals Plugin](https://github.com/alphanodes/additionals) adds a macro button to the toolbar which is missing in the current version of this theme. In the default theme the button show a puzzle symbol.