### PR TITLE
Add sidebar icon to dot menu

### DIFF
--- a/src/styles/components/_icon.scss
+++ b/src/styles/components/_icon.scss
@@ -1,5 +1,5 @@
 $overridden-selectors: '.icon-add', '.icon-edit', '.icon-copy', '.icon-del', '.icon-move', '.icon-save', '.icon-download', '.icon-cancel', '.icon-multiple', '.icon-folder', '.open:not(.dmsf-expander)', '.icon-folder', '.icon-package', '.icon-user', '.icon-project', '.icon-projects', '.icon-help', '.icon-attachment', '.icon-history', '.icon-time-entry', '.icon-time', '.icon-time-add', '.icon-stats', '.icon-warning', '.icon-error', '.icon-fav', '.icon-fav-off', '.icon-reload', '.icon-lock', '.icon-locked', '.icon-unlock', '.icon-checked', '.icon-comment', '.icon-comments', '.icon-summary', '.icon-server-authentication', '.icon-issue', '.icon-zoom-in', '.icon-zoom-out', '.icon-passwd', '.icon-arrow-right', '.icon-test', '.icon-sticky', '.icon-email', '.icon-email-disabled', '.icon-email-add', '.icon-ok', '.icon-not-ok', '.icon-link-break', '.icon-list', '.icon-close', '.icon-settings', '.icon-roles', '.icon-issue-edit', '.icon-workflows', '.icon-custom-fields', '.icon-plugins', '.icon-news', '.icon-issue-closed', '.icon-issue-note', '.icon-changeset', '.icon-message', '.icon-reply', '.icon-wiki-page', '.icon-wiki-page', '.icon-document', '.icon-add-bullet', '.icon-shared', '.icon-actions', '.icon-expanded',
-'.icon-expended', '.icon-collapsed', '.icon-bookmark', '.icon-bookmark-off', '.icon-sort-handle', '.icon-sorted-asc', '.icon-sorted-desc', '.icon-toggle-plus', '.icon-toggle-minus', '.icon-file', '.icon-clear-query', '.icon-import', '.icon-group:not(.name):not(.group)', '.icon-bookmarked-project', '.icon-copy-link';
+'.icon-expended', '.icon-sidebar', '.icon-collapsed', '.icon-bookmark', '.icon-bookmark-off', '.icon-sort-handle', '.icon-sorted-asc', '.icon-sorted-desc', '.icon-toggle-plus', '.icon-toggle-minus', '.icon-file', '.icon-clear-query', '.icon-import', '.icon-group:not(.name):not(.group)', '.icon-bookmarked-project', '.icon-copy-link';
 
 // .atomアイコンは個別に置き換え
 a.atom { background: transparent; padding: 2px 0px 3px 16px; }
@@ -87,6 +87,7 @@ a.atom:before { /* fa-atom */ @include fontAwesome('f143', 'Solid'); }
 /* Support https: //redmine.org/issues/36149 */
 .icon-expanded:before { /* fa-angle-down */ @include fontAwesome('f107', 'Solid'); }
 .icon-expended:before { /* fa-angle-down */ @include fontAwesome('f107', 'Solid'); }
+.icon-sidebar:before { /* fa-left-right */ @include fontAwesome('f337', 'Solid'); }
 
 .icon-collapsed:before { /* fa-angle-right */ @include fontAwesome('f105', 'Solid'); }
 .icon-bookmark { /* fa-bookmark */ @include ColoredIconInBeforeOfElement('f02e', 'Solid', $color-bookmark-icon); }


### PR DESCRIPTION
The sidebar toogle icon was missing in the dot menu (three dots next to the block select field).