### PR TITLE
Upgrade actions/upload-pages-artifact version

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: ./storybook
         run: npm run build-storybook
 
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: storybook/storybook-static
 


### PR DESCRIPTION
https://github.com/farend/redmine_theme_farend_bleuclair/actions/runs/13430834950
```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```
The GitHub Actions workflow failed due to an outdated version of actions/upload-pages-artifact, so I will update it to a newer version.

After running it manually, it failed for a different reason, but at least this error has been resolved.
(The error during manual execution is likely due to a different branch.) https://github.com/farend/redmine_theme_farend_bleuclair/actions/runs/13430934449