### PR TITLE
Upgrade actions/deploy-pages version

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR upgrades `actions/deploy-pages` from v1 to v4 to fix the [deployment failure in the GitHub Actions workflow](https://github.com/farend/redmine_theme_farend_bleuclair/actions/runs/13514082092/job/37759581833).  

I have confirmed that this change allows the deployment to succeed in a forked repository.  
You can see the successful run here: 
 https://github.com/ishikawa999/redmine_theme_farend_bleuclair/actions/runs/13514282079
