### PR TITLE
Remove outdated RedMica description from README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,8 +11,6 @@ Redmine用のカスタムテーマです。
 また、日本語環境でも見やすくなるようにフォントサイズや行間などを変更しています。
 メニューの位置や配色はデフォルトのテーマに近いので、既存のテーマに慣れ親しんだ方も違和感なくご利用になれます。
 
-[「今日使える明日のRedmine」RedMica](https://www.farend.co.jp/products/redmica/)(Redmine互換のオープンソースソフトウェア)にはBleuclairテーマが標準で入っています。
-
 このテーマは、Redmimeのクラウドサービス [My Redmine](https://hosting.redmine.jp/) のサービス提供用に開発し、OSSとして公開したものです。
 
 [<img src="https://www.farend.co.jp/files/myredmine-logo/hz/myredmine-logo-hz.png" width="250">](https://hosting.redmine.jp/)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Custom theme for Redmine.
 I created a theme using Cool Colors with an awareness of making the interface look more modern than the default Redmine.
 The position and color scheme of the menu are close to the default theme, so even those who are familiar with existing themes can use it without any discomfort.
 
-Bleuclair theme is used as standard for [RedMica - the future Redmine you can get today](https://www.farend.co.jp/products/redmica/) (RedMica is yet another distribution of Redmine)
-
 The theme was originally developed for the cloud-based Redmine service [My Redmine](https://www.redminecloud.net/), and was later released as open source.
 
 [<img src="https://www.farend.co.jp/files/myredmine-logo/hz/myredmine-logo-hz.png" width="250">](https://www.redminecloud.net/)


### PR DESCRIPTION
Bleuclair is no longer a standard theme in RedMica 4.0.